### PR TITLE
Harden test coverage to 100% and add CI coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: python -m pip install -e ".[dev]"
 
       - name: Run tests
-        run: pytest tests/ -v
+        run: pytest tests/ -v --cov=planaco --cov-report=term-missing
 
   lint:
     name: Lint and type-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,14 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 
+[tool.coverage.run]
+source = ["planaco"]
+
+[tool.coverage.report]
+# Coverage gate: the suite covers 100%; fail if it regresses below 99%.
+fail_under = 99
+show_missing = true
+
 [tool.black]
 line-length = 88
 target-version = ["py38", "py39", "py310", "py311", "py312"]

--- a/src/planaco/distributions.py
+++ b/src/planaco/distributions.py
@@ -653,5 +653,6 @@ def create_distribution(
             max_value=max_value,
         )
 
-    # Should never reach here due to registry check
-    raise ValueError(f"Unknown estimator: {estimator}")
+    # Should never reach here: the registry check above rejects unknown
+    # estimators, and every registered estimator is handled in the chain.
+    raise ValueError(f"Unknown estimator: {estimator}")  # pragma: no cover

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Tests for Planaco CLI commands."""
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -29,6 +30,16 @@ def valid_config_path():
 def seeded_config_path():
     """Path to test configuration with seed."""
     return str(FIXTURES_DIR / "project_with_seed.yaml")
+
+
+@pytest.fixture
+def invalid_config_path():
+    """Path to a config that exists but fails validation (raises ConfigError)."""
+    return str(FIXTURES_DIR / "invalid_missing_tasks.yaml")
+
+
+# Commands that load a config file and therefore share the same error handling.
+CONFIG_COMMANDS = ["run", "stats", "plot", "graph"]
 
 
 class TestMainGroup:
@@ -336,3 +347,45 @@ class TestSeedFunctionality:
             json_part = output[json_start:]
             data = json.loads(json_part)
             assert "mean" in data
+
+
+class TestErrorHandling:
+    """Tests for the error-handling arms of the config-loading commands."""
+
+    @pytest.mark.parametrize("command", CONFIG_COMMANDS)
+    def test_config_error_exits_1(self, runner, command, invalid_config_path):
+        """A config that fails validation hits the ConfigError arm (exit 1)."""
+        result = runner.invoke(main, [command, invalid_config_path])
+        assert result.exit_code == 1
+        assert "Error" in result.output
+
+    @pytest.mark.parametrize("command", CONFIG_COMMANDS)
+    def test_unexpected_error_exits_1(
+        self, runner, command, valid_config_path, monkeypatch
+    ):
+        """An unexpected exception hits the generic Exception arm (exit 1)."""
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("unexpected failure")
+
+        # Every config command builds the project; force that step to blow up.
+        monkeypatch.setattr("planaco.cli.build_project_from_config", _boom)
+
+        result = runner.invoke(main, [command, valid_config_path])
+        assert result.exit_code == 1
+        assert "Error" in result.output
+        assert "unexpected failure" in result.output
+
+
+class TestModuleEntrypoint:
+    """Cover the ``if __name__ == '__main__'`` guard."""
+
+    def test_module_runs_as_main(self, monkeypatch):
+        import runpy
+
+        monkeypatch.setattr(sys, "argv", ["planaco", "--help"])
+        # Drop the cached module so runpy executes it cleanly as __main__.
+        monkeypatch.delitem(sys.modules, "planaco.cli", raising=False)
+        with pytest.raises(SystemExit) as exc:
+            runpy.run_module("planaco.cli", run_name="__main__")
+        assert exc.value.code == 0

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -807,3 +807,90 @@ class TestDistributionRoundTrip:
         restored_samples = [restored.sample() for _ in range(50)]
 
         assert original_samples == restored_samples
+
+
+class TestDistributionAbstractBase:
+    """Cover the abstract base method bodies via a concrete subclass.
+
+    The ``pass`` bodies of the abstract methods are never executed when a
+    concrete distribution overrides them, so we explicitly invoke them via
+    ``super()`` to confirm they exist and are inert.
+    """
+
+    def test_abstract_method_bodies(self):
+        from planaco.distributions import Distribution
+
+        class _Concrete(Distribution):
+            @property
+            def name(self) -> str:
+                return super().name
+
+            def sample(self) -> float:
+                return super().sample()
+
+            def validate(self) -> None:
+                return super().validate()
+
+            def get_display_params(self) -> str:
+                return super().get_display_params()
+
+            def to_dict(self):
+                return super().to_dict()
+
+        d = _Concrete()
+        assert d.name is None
+        assert d.sample() is None
+        assert d.validate() is None
+        assert d.get_display_params() is None
+        assert d.to_dict() is None
+
+
+class TestPERTModeEdgeCases:
+    """Cover the alpha/beta branches when the mode sits on a boundary."""
+
+    def test_mode_equals_min(self):
+        dist = PERTDistribution(min_value=2.0, mode_value=2.0, max_value=5.0)
+        assert dist._alpha == 1.0
+        assert dist._beta == dist.lamb + 1
+        for _ in range(50):
+            assert 2.0 <= dist.sample() <= 5.0
+
+    def test_mode_equals_max(self):
+        dist = PERTDistribution(min_value=2.0, mode_value=5.0, max_value=5.0)
+        assert dist._alpha == dist.lamb + 1
+        assert dist._beta == 1.0
+        for _ in range(50):
+            assert 2.0 <= dist.sample() <= 5.0
+
+
+class TestPERTValidation:
+    """Cover the non-negative validation branches for mode and max."""
+
+    def test_negative_mode_raises(self):
+        with pytest.raises(ValueError, match="mode_value must be non-negative"):
+            PERTDistribution(min_value=0.0, mode_value=-1.0, max_value=5.0)
+
+    def test_negative_max_raises(self):
+        with pytest.raises(ValueError, match="max_value must be non-negative"):
+            PERTDistribution(min_value=0.0, mode_value=0.0, max_value=-1.0)
+
+
+class TestRejectionSamplingFallback:
+    """Cover the clamp fallback when rejection sampling never lands in bounds."""
+
+    def test_normal_fallback_clamps_to_bounds(self, monkeypatch):
+        import planaco.distributions as dist_mod
+
+        dist = NormalDistribution(mean=5.0, std_dev=1.0, min_value=0.0, max_value=10.0)
+        # Force every draw out of bounds so the loop exhausts and clamps.
+        monkeypatch.setattr(dist_mod.random, "gauss", lambda mu, sigma: 999.0)
+        assert dist.sample() == 10.0
+
+    def test_lognormal_fallback_clamps_to_bounds(self, monkeypatch):
+        import planaco.distributions as dist_mod
+
+        dist = LogNormalDistribution(
+            mean=5.0, std_dev=1.0, min_value=0.0, max_value=10.0
+        )
+        monkeypatch.setattr(dist_mod.random, "lognormvariate", lambda mu, sigma: 999.0)
+        assert dist.sample() == 10.0

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -846,3 +846,57 @@ def test_empty_project_estimate_returns_zero():
     """A project with no tasks must estimate 0 without crashing."""
     p = Project(name="Empty")
     assert p.estimate() == 0.0
+
+
+def test_empty_project_critical_path_length_returns_zero():
+    """The forward-pass critical-path helper short-circuits on an empty project."""
+    p = Project(name="Empty")
+    assert p._calculate_critical_path({}) == 0.0
+
+
+def test_empty_project_critical_tasks_returns_empty():
+    """The CPM helper returns no critical tasks and zero duration when empty."""
+    p = Project(name="Empty")
+    assert p._get_critical_tasks_for_run({}) == (set(), 0.0)
+
+
+def test_dependency_graph_layout_falls_back_to_spring(monkeypatch, tmp_path):
+    """When graphviz and shell layouts both fail, fall back to spring layout."""
+    import planaco.project as project_mod
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("layout unavailable")
+
+    monkeypatch.setattr(project_mod.nx.nx_agraph, "graphviz_layout", _raise)
+    monkeypatch.setattr(project_mod.nx, "shell_layout", _raise)
+
+    p = Project(name="Graph")
+    a = Task(name="A", min_duration=1, mode_duration=2, max_duration=3)
+    b = Task(name="B", min_duration=1, mode_duration=2, max_duration=3)
+    p.add_task(a)
+    p.add_task(b, depends_on=[a])
+
+    out = tmp_path / "graph.png"
+    fig = p.plot_dependency_graph(save_path=str(out))
+    assert out.exists()
+    assert fig is not None
+
+
+def test_dependency_graph_without_save_path_shows(monkeypatch):
+    """With no save_path, plot_dependency_graph displays instead of saving."""
+    import planaco.project as project_mod
+
+    shown = {"called": False}
+
+    def _fake_show(*args, **kwargs):
+        shown["called"] = True
+
+    monkeypatch.setattr(project_mod.plt, "show", _fake_show)
+
+    p = Project(name="Graph")
+    a = Task(name="A", min_duration=1, mode_duration=2, max_duration=3)
+    p.add_task(a)
+
+    fig = p.plot_dependency_graph()
+    assert shown["called"] is True
+    assert fig is not None

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -181,3 +181,11 @@ def test_task_normal_estimator_string():
     assert task.estimator == "normal"
     # Distribution is None since no params provided
     assert task.distribution is None
+
+
+def test_estimate_without_distribution_raises():
+    """Task created without duration params has no distribution; estimate() raises."""
+    task = Task(name="Unconfigured")
+    assert task.distribution is None
+    with pytest.raises(ValueError, match="distribution not configured"):
+        task.estimate()


### PR DESCRIPTION
## Summary

Closes the remaining test-coverage gaps across the codebase (was **94% → 100%**) and adds a CI gate so it can't silently regress. Tests + config only — no production behavior changes.

| Module | Before | After |
|---|---|---|
| `cli.py` | 83% | **100%** |
| `distributions.py` | 95% | **100%** |
| `project.py` | 98% | **100%** |
| `task.py` | 98% | **100%** |

## What changed

- **CLI** — cover the `ConfigError` and generic-exception error arms for all four config commands (`run`/`stats`/`plot`/`graph`), plus the `__main__` entrypoint guard.
- **distributions** — cover abstract base method bodies, PERT `mode==min`/`mode==max` branches, negative mode/max validation, and the Normal/LogNormal resample-fallback clamps. The one genuinely unreachable line (post-registry-check `raise`) is marked `# pragma: no cover` with a reason rather than tested contrivedly.
- **project** — cover empty-project critical-path early returns, the graph spring-layout fallback, and the `plt.show()` display branch.
- **task** — cover `estimate()` raising when no distribution is configured.
- **coverage gate** — `fail_under = 99` in `pyproject.toml` and `--cov` wired into the CI test step.

## Verification

- `pytest`: **267 passed**, total coverage **100.00%** (gate at 99%).
- `ruff`, `black --check`, `mypy` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)