### PR TITLE
Drop unused networkx and seaborn dependencies

### DIFF
--- a/example/example.ipynb
+++ b/example/example.ipynb
@@ -59,7 +59,7 @@
    "outputs": [],
    "source": [
     "from planaco import Task, Project\n",
-    "import seaborn as sns"
+    "from planaco.charts import histogram"
    ]
   },
   {
@@ -163,7 +163,9 @@
     }
    },
    "outputs": [],
-   "source": "sns.histplot(task1_estimates, kde=False);"
+   "source": [
+    "histogram(task1_estimates, title=\"Problem definition — estimate distribution\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -266,7 +268,9 @@
     }
    },
    "outputs": [],
-   "source": "sns.histplot(task2_estimates, kde=False)"
+   "source": [
+    "histogram(task2_estimates, title=\"Convince CEO — estimate distribution\")"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,8 @@ keywords = [
 dependencies = [
     "click>=7.0",
     "matplotlib>=3.0",
-    "seaborn>=0.11",
     "numpy>=1.18",
     "PyYAML>=5.0",
-    "networkx>=2.5",
     "cairosvg>=2.5",
 ]
 

--- a/src/planaco/charts.py
+++ b/src/planaco/charts.py
@@ -195,8 +195,13 @@ def histogram(
     show_percentiles: bool = False,
     percentiles: Optional[List[int]] = None,
     kde: bool = False,
+    title: Optional[str] = None,
 ) -> Chart:
-    """Render a histogram of simulated durations as an on-brand SVG chart."""
+    """Render a histogram of simulated durations as an on-brand SVG chart.
+
+    ``title`` overrides the default heading (useful for charting a single
+    task's estimates rather than a whole project).
+    """
     if percentiles is None:
         percentiles = [50, 85, 95]
     c = theme_colors(theme)
@@ -221,7 +226,8 @@ def histogram(
     parts = _open_svg(W, H, c["bg"])
 
     # Title
-    title = f"{unit.capitalize()} to project completion · n = {n:,}"
+    if title is None:
+        title = f"{unit.capitalize()} to project completion · n = {n:,}"
     parts.append(
         _text(pad_l, 34, title, fill=c["fg"], size=20, weight="700", font=_FONT_DISPLAY)
     )

--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -111,6 +111,12 @@ def test_histogram_default_n_uses_length(sims):
     assert f"n = {len(sims):,}" in svg
 
 
+def test_histogram_custom_title(sims):
+    svg = str(charts.histogram(sims, title="Task 1 estimate distribution"))
+    assert "Task 1 estimate distribution" in svg
+    assert "to project completion" not in svg
+
+
 def test_histogram_degenerate_single_value():
     # All identical samples -> single bin, no span; must not crash.
     svg = str(charts.histogram([5.0] * 50, kde=True))

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -657,10 +657,6 @@ def test_critical_path_complex_dag():
 
 def test_plot_dependency_graph_with_criticality(tmp_path):
     """Test that plot_dependency_graph works with criticality coloring"""
-    import matplotlib
-
-    matplotlib.use("Agg")  # Non-interactive backend for testing
-
     task1 = Task(name="Task1", min_duration=5, mode_duration=5, max_duration=5)
     task2 = Task(name="Task2", min_duration=3, mode_duration=3, max_duration=3)
 

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -8,14 +8,9 @@ fails the test suite instead of failing for a new user.
 import re
 from pathlib import Path
 
-import matplotlib
+import pytest
 
-matplotlib.use("Agg")  # Non-interactive backend for testing
-
-import matplotlib.pyplot as plt  # noqa: E402
-import pytest  # noqa: E402
-
-from planaco.config import build_project_from_config, load_config  # noqa: E402
+from planaco.config import build_project_from_config, load_config
 
 README_PATH = Path(__file__).resolve().parent.parent / "README.md"
 
@@ -46,8 +41,6 @@ def test_readme_python_examples_run(tmp_path, monkeypatch):
                 f"README.md python block {i} raised {type(e).__name__}: {e}\n"
                 f"---\n{block}---"
             )
-        finally:
-            plt.close("all")
 
 
 def test_readme_yaml_examples_load(tmp_path):


### PR DESCRIPTION
## Summary

A careful, repo-wide scan confirmed **`networkx`** and **`seaborn`** are no longer used by the library, so this removes them from the runtime dependencies — slimming the install now that charts render as native SVG.

## Findings

| Dependency | Library use? | Verdict |
|---|---|---|
| `networkx` | **None** — DAG validation, topological sort, and critical-path math are all hand-rolled pure Python; networkx only ever did the old matplotlib graph *layout*, now handled by `charts._layer_of()` | **Removed** |
| `seaborn` | **None** — only `example.ipynb` used it for ad-hoc task histograms | **Removed** (notebook modernized) |
| `matplotlib` | **Yes** — `style.py`'s `apply_planaco_style()` / `CRITICALITY_CMAP` / `mode_bar_colors` (public API for theming user matplotlib plots) import it at package load | **Kept** |

## Changes

- Remove `networkx` and `seaborn` from `[project.dependencies]`.
- Modernize `example.ipynb` to use planaco's own SVG charts instead of `sns.histplot`.
- Add an optional `title` to `charts.histogram()` (so a single task's estimates can be labeled).
- Remove two now-vestigial `matplotlib` imports from tests (plots are SVG; the `Agg` backend / `plt.close` calls were dead).

## Verification

With **both packages uninstalled from the environment**, `import planaco`, `project.plot()`, and `project.plot_dependency_graph()` all work. Full gate suite green: ruff ✓ · black ✓ · mypy ✓ · **pytest 309 passed, 100% coverage**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)