### PR TITLE
Strip matplotlib: fully SVG-native package

### DIFF
--- a/brand/STYLE_GUIDE.md
+++ b/brand/STYLE_GUIDE.md
@@ -102,37 +102,34 @@ body `16–18px/400` · small/label `13–14px` · code `13–15px`.
 Headings use tight tracking (`-0.02em`). Numbers in tables and stat readouts are
 set in JetBrains Mono so they align.
 
-In matplotlib, the font stack falls back gracefully:
-`Inter → Space Grotesk → Helvetica Neue → Arial → DejaVu Sans`, so plots still
-render cleanly on machines without the brand fonts installed.
+In the SVG charts the font stack falls back gracefully:
+`Inter → Space Grotesk → Helvetica Neue → Arial → sans-serif`, so charts still
+render cleanly where the brand fonts aren't installed.
 
 ---
 
 ## 4. Data visualization
 
-This is where the brand earns its keep. Default matplotlib/seaborn output is
-off-brand; apply the Planaco theme to fix it in one call:
+This is where the brand earns its keep. Planaco renders charts as native SVG
+(`planaco.charts`), so the on-brand look is built in — no theming call needed:
 
 ```python
-from planaco.style import apply_planaco_style
-
-apply_planaco_style("light")   # or "dark"
-fig = project.plot(n=10000, show_percentiles=True)
+chart = project.plot(n=10000, show_percentiles=True)
+chart.save("estimate.svg")   # or .png (rasterized via cairosvg)
 ```
 
 **Rules for every chart**
 
-- **Background:** canvas/paper, not seaborn grey. Top and right spines removed.
+- **Background:** canvas/paper, never grey. Top and right spines removed.
 - **Grid:** horizontal only, very low contrast. The data is the hero.
 - **Distribution bars:** navy/slate fill with a subtle stroke.
-- **The mode bar is gold** — the single tallest bar, echoing the logo. Use
-  `planaco.style.mode_bar_colors(counts, theme=...)` to color a histogram.
+- **The mode bar is gold** — the single tallest bar, echoing the logo.
 - **Percentile markers:** dashed vertical lines, labeled, colored gold/amber/coral
   for P50/P85/P95 via `planaco.style.percentile_color(p)`.
 - **CDF:** gold line over a translucent gold fill; a single guide line for the
   percentile you're highlighting.
 - **Dependency graph:** navy nodes; nodes on the critical path are gold. The
-  criticality gradient is `planaco.style.CRITICALITY_CMAP`
+  criticality gradient interpolates `planaco.style.CRITICALITY_STOPS`
   (slate → gold → coral, low → high), replacing the old green→red ramp.
 - **Titles** in Space Grotesk weight; axis labels in Inter; numeric ticks in mono.
 
@@ -148,9 +145,9 @@ Never imply false certainty — the whole point is the range.
 
 ## 6. Applying the system
 
-**Python / matplotlib** — `src/planaco/style.py`
-: `apply_planaco_style(theme)`, `PALETTE`, `PERCENTILE_COLORS`,
-  `percentile_color(p)`, `mode_bar_colors(...)`, `CRITICALITY_CMAP`.
+**Python** — tokens in `src/planaco/style.py` (`PALETTE`, `theme_colors(theme)`,
+`PERCENTILE_COLORS`, `percentile_color(p)`, `CRITICALITY_STOPS`), consumed by the
+SVG renderer in `src/planaco/charts.py`.
 
 **Web / CSS** — copy the `:root` and `[data-theme="light"]` custom properties from
 [`website/index.html`](../website/index.html). They are the same tokens listed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ keywords = [
 ]
 dependencies = [
     "click>=7.0",
-    "matplotlib>=3.0",
     "numpy>=1.18",
     "PyYAML>=5.0",
     "cairosvg>=2.5",
@@ -82,7 +81,6 @@ strict_equality = true
 
 [[tool.mypy.overrides]]
 module = [
-    "matplotlib.*",
     "numpy.*",
     "click.*",
     "yaml.*",

--- a/src/planaco/style.py
+++ b/src/planaco/style.py
@@ -1,9 +1,9 @@
-"""On-brand matplotlib/seaborn styling for Planaco plots.
+"""On-brand design tokens for Planaco's SVG charts.
 
-This module is the library-side implementation of the Planaco brand system.
-It restyles matplotlib so that plots produced by :class:`planaco.Project`
-(histograms, cumulative distributions, dependency graphs) match the logo,
-the documentation, and the website.
+This module holds the Planaco brand system as plain data: the color palette,
+per-theme tokens, percentile marker colors, and the critical-path gradient
+stops. The SVG renderer in :mod:`planaco.charts` consumes these so the charts,
+the documentation, and ``website/index.html`` all stay in sync.
 
 The brand motif is a histogram whose modal (most likely) bar is gold. Every
 chart echoes it: navy/slate distribution bars, a gold mode bar, and percentile
@@ -12,31 +12,19 @@ markers that warm from gold to coral as risk climbs.
 See ``brand/STYLE_GUIDE.md`` for the full design system and ``website/index.html``
 for a live reference.
 
-Quick start
------------
->>> from planaco.style import apply_planaco_style, mode_bar_colors, percentile_color
->>> apply_planaco_style("light")          # or "dark"
->>> # then draw plots as usual; they pick up the theme via rcParams
-
 Public API
 ----------
-apply_planaco_style(theme)
-    Apply the theme to matplotlib's global rcParams. Returns the resolved
-    color dict for the chosen theme.
 PALETTE
     Brand colors that do not change between themes.
+theme_colors(theme)
+    Resolved per-theme color tokens (``"light"`` / ``"dark"``).
 PERCENTILE_COLORS, percentile_color(p)
     Colors for P50 / P85 / P95 markers (gold / amber / coral).
-mode_bar_colors(counts, theme)
-    Per-bar colors for a histogram, highlighting the tallest (modal) bar in gold.
-CRITICALITY_CMAP
-    Colormap for critical-path frequency (slate -> gold -> coral).
+CRITICALITY_STOPS
+    Color stops for the critical-path frequency gradient (slate -> gold -> coral).
 """
 
-from typing import Dict, List, Sequence
-
-import matplotlib as mpl
-from matplotlib.colors import LinearSegmentedColormap
+from typing import Dict, List
 
 # ---------------------------------------------------------------------------
 # Brand constants (theme-independent)
@@ -62,15 +50,8 @@ PERCENTILE_COLORS: Dict[int, str] = {
 }
 
 #: Color stops for the critical-path frequency gradient (low -> high):
-#: cool slate -> brand gold -> hot coral. Shared by the matplotlib colormap
-#: and the SVG renderer so both stay in sync.
+#: cool slate -> brand gold -> hot coral. Consumed by the SVG renderer.
 CRITICALITY_STOPS: List[str] = ["#3a5a8c", "#e6b94d", "#f0846b"]
-
-#: Critical-path frequency gradient: low (cool slate) -> high (hot coral),
-#: with the brand gold in the middle. Replaces the generic green -> red ramp.
-CRITICALITY_CMAP: LinearSegmentedColormap = LinearSegmentedColormap.from_list(
-    "planaco_criticality", CRITICALITY_STOPS
-)
 
 # Per-theme color tokens. Mirrors the CSS custom properties in website/index.html.
 _THEMES: Dict[str, Dict[str, str]] = {
@@ -96,16 +77,6 @@ _THEMES: Dict[str, Dict[str, str]] = {
     },
 }
 
-#: Font fallback chain. Brand fonts first, DejaVu Sans (always present) last so
-#: plots render without warnings on machines lacking Inter / Space Grotesk.
-_FONT_STACK: List[str] = [
-    "Inter",
-    "Space Grotesk",
-    "Helvetica Neue",
-    "Arial",
-    "DejaVu Sans",
-]
-
 
 def theme_colors(theme: str = "light") -> Dict[str, str]:
     """Return the resolved color token dict for a theme.
@@ -118,7 +89,7 @@ def theme_colors(theme: str = "light") -> Dict[str, str]:
     Returns
     -------
     Dict[str, str]
-        Color tokens (``bg``, ``fg``, ``muted``, ``grid``, ``bar``,
+        Color tokens (``bg``, ``fg``, ``muted``, ``grid``, ``axis``, ``bar``,
         ``bar_edge``, ``gold``).
 
     Raises
@@ -132,92 +103,6 @@ def theme_colors(theme: str = "light") -> Dict[str, str]:
         )
     # Return a copy so callers can't mutate the module-level token table.
     return dict(_THEMES[theme])
-
-
-def apply_planaco_style(theme: str = "light") -> Dict[str, str]:
-    """Apply the Planaco theme to matplotlib's global rcParams.
-
-    Call this once before drawing plots. It restyles backgrounds, spines, grid,
-    fonts, and the default color cycle to match the brand.
-
-    Parameters
-    ----------
-    theme : str
-        Either ``"light"`` (default) or ``"dark"``.
-
-    Returns
-    -------
-    Dict[str, str]
-        The resolved color tokens for the chosen theme, so callers can reuse
-        them (e.g. to color a mode bar or a percentile line).
-
-    Raises
-    ------
-    ValueError
-        If ``theme`` is not a known theme name.
-
-    Examples
-    --------
-    >>> from planaco.style import apply_planaco_style
-    >>> colors = apply_planaco_style("dark")
-    >>> colors["gold"]
-    '#f5d97a'
-    """
-    c = theme_colors(theme)
-
-    mpl.rcParams.update(
-        {
-            # Surfaces
-            "figure.facecolor": c["bg"],
-            "axes.facecolor": c["bg"],
-            "savefig.facecolor": c["bg"],
-            "savefig.edgecolor": c["bg"],
-            # Spines / frame
-            "axes.edgecolor": c["grid"],
-            "axes.linewidth": 1.0,
-            "axes.spines.top": False,
-            "axes.spines.right": False,
-            # Text
-            "text.color": c["fg"],
-            "axes.labelcolor": c["fg"],
-            "axes.titlecolor": c["fg"],
-            "axes.titlesize": 14,
-            "axes.titleweight": "bold",
-            "axes.labelsize": 12,
-            "xtick.color": c["muted"],
-            "ytick.color": c["muted"],
-            "xtick.labelcolor": c["muted"],
-            "ytick.labelcolor": c["muted"],
-            # Grid: horizontal only, low contrast
-            "axes.grid": True,
-            "axes.grid.axis": "y",
-            "grid.color": c["grid"],
-            "grid.linewidth": 0.8,
-            "grid.alpha": 1.0,
-            # Bars / patches
-            "patch.edgecolor": c["bar_edge"],
-            "patch.force_edgecolor": True,
-            # Fonts
-            "font.family": "sans-serif",
-            "font.sans-serif": _FONT_STACK,
-            "font.size": 11,
-            # Figure
-            "figure.figsize": (10, 6),
-            "figure.dpi": 110,
-            # Default categorical cycle: bar, teal, amber, coral, gold
-            # mpl.cycler is re-exported at runtime but absent from the stubs.
-            "axes.prop_cycle": mpl.cycler(  # type: ignore[attr-defined]
-                color=[
-                    c["bar"],
-                    PALETTE["teal"],
-                    PALETTE["amber"],
-                    PALETTE["coral"],
-                    c["gold"],
-                ]
-            ),
-        }
-    )
-    return c
 
 
 def percentile_color(p: int) -> str:
@@ -244,40 +129,3 @@ def percentile_color(p: int) -> str:
     '#f0846b'
     """
     return PERCENTILE_COLORS.get(p, PALETTE["coral"])
-
-
-def mode_bar_colors(counts: Sequence[float], theme: str = "light") -> List[str]:
-    """Return per-bar colors for a histogram, highlighting the modal bar.
-
-    The single tallest bar (the mode) is colored gold to echo the logo; all
-    other bars use the theme's navy/slate bar color.
-
-    Parameters
-    ----------
-    counts : Sequence[float]
-        Bar heights, e.g. the counts returned by ``numpy.histogram`` or
-        matplotlib's ``hist``.
-    theme : str
-        Either ``"light"`` (default) or ``"dark"``.
-
-    Returns
-    -------
-    List[str]
-        One hex color per bar.
-
-    Raises
-    ------
-    ValueError
-        If ``theme`` is not a known theme name.
-
-    Examples
-    --------
-    >>> mode_bar_colors([1, 5, 2], theme="light")
-    ['#2a4a7c', '#e6b94d', '#2a4a7c']
-    """
-    c = theme_colors(theme)
-    counts = list(counts)
-    if not counts:
-        return []
-    peak = max(range(len(counts)), key=lambda i: counts[i])
-    return [c["gold"] if i == peak else c["bar"] for i in range(len(counts))]

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,22 +1,12 @@
-"""Tests for the planaco.style brand theming module."""
+"""Tests for the planaco.style design tokens."""
 
 import re
 
-import matplotlib as mpl
 import pytest
-from matplotlib.colors import LinearSegmentedColormap
 
 from planaco import style
 
 HEX_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
-
-
-@pytest.fixture(autouse=True)
-def _restore_rcparams():
-    """Snapshot and restore global rcParams so theming doesn't leak."""
-    original = mpl.rcParams.copy()
-    yield
-    mpl.rcParams.update(original)
 
 
 # --------------------------------------------------------------------------- #
@@ -31,13 +21,11 @@ def test_percentile_colors_are_hex():
     assert set(style.PERCENTILE_COLORS) == {50, 85, 95}
 
 
-def test_criticality_cmap_is_colormap():
-    assert isinstance(style.CRITICALITY_CMAP, LinearSegmentedColormap)
-    # Endpoints: cool slate at 0.0, hot coral at 1.0; both opaque.
-    low = style.CRITICALITY_CMAP(0.0)
-    high = style.CRITICALITY_CMAP(1.0)
-    assert low[3] == 1.0 and high[3] == 1.0
-    assert low != high
+def test_criticality_stops_are_hex():
+    # slate -> gold -> coral, low -> high.
+    assert all(HEX_RE.match(v) for v in style.CRITICALITY_STOPS)
+    assert len(style.CRITICALITY_STOPS) == 3
+    assert style.CRITICALITY_STOPS[0] != style.CRITICALITY_STOPS[-1]
 
 
 # --------------------------------------------------------------------------- #
@@ -72,33 +60,6 @@ def test_theme_colors_returns_copy():
 
 
 # --------------------------------------------------------------------------- #
-# apply_planaco_style
-# --------------------------------------------------------------------------- #
-@pytest.mark.parametrize("theme", ["light", "dark"])
-def test_apply_planaco_style_sets_rcparams(theme):
-    colors = style.apply_planaco_style(theme)
-    assert mpl.rcParams["axes.facecolor"] == colors["bg"]
-    assert mpl.rcParams["figure.facecolor"] == colors["bg"]
-    assert mpl.rcParams["axes.spines.top"] is False
-    assert mpl.rcParams["axes.spines.right"] is False
-    assert mpl.rcParams["font.family"] == ["sans-serif"]
-    assert mpl.rcParams["font.sans-serif"][0] == "Inter"
-    # First color in the cycle is the navy/slate bar color.
-    cycle_colors = mpl.rcParams["axes.prop_cycle"].by_key()["color"]
-    assert cycle_colors[0] == colors["bar"]
-
-
-def test_apply_planaco_style_returns_colors():
-    colors = style.apply_planaco_style("dark")
-    assert colors == style.theme_colors("dark")
-
-
-def test_apply_planaco_style_invalid_raises():
-    with pytest.raises(ValueError, match="Unknown theme"):
-        style.apply_planaco_style("neon")
-
-
-# --------------------------------------------------------------------------- #
 # percentile_color
 # --------------------------------------------------------------------------- #
 def test_percentile_color_known():
@@ -109,27 +70,3 @@ def test_percentile_color_known():
 
 def test_percentile_color_unknown_falls_back_to_coral():
     assert style.percentile_color(99) == style.PALETTE["coral"]
-
-
-# --------------------------------------------------------------------------- #
-# mode_bar_colors
-# --------------------------------------------------------------------------- #
-def test_mode_bar_colors_highlights_tallest():
-    colors = style.mode_bar_colors([1, 5, 2], theme="light")
-    light = style.theme_colors("light")
-    assert colors == [light["bar"], light["gold"], light["bar"]]
-
-
-def test_mode_bar_colors_dark_theme():
-    colors = style.mode_bar_colors([3, 1], theme="dark")
-    dark = style.theme_colors("dark")
-    assert colors == [dark["gold"], dark["bar"]]
-
-
-def test_mode_bar_colors_empty():
-    assert style.mode_bar_colors([]) == []
-
-
-def test_mode_bar_colors_invalid_theme_raises():
-    with pytest.raises(ValueError, match="Unknown theme"):
-        style.mode_bar_colors([1, 2, 3], theme="nope")

--- a/website/index.html
+++ b/website/index.html
@@ -432,7 +432,7 @@
     <div class="section-head">
       <div class="section-tag">Brand &amp; style system</div>
       <h2>The tokens behind everything above</h2>
-      <p>One palette and three typefaces, applied consistently across the site, the docs, and the library's matplotlib output.</p>
+      <p>One palette and three typefaces, applied consistently across the site, the docs, and the library's SVG chart output.</p>
     </div>
 
     <h3 style="font-size:15px; text-transform:uppercase; letter-spacing:.1em; color:var(--text-muted); margin-bottom:18px; font-family:'JetBrains Mono',monospace;">Core palette</h3>


### PR DESCRIPTION
## Summary

planaco now renders charts entirely through its native SVG renderer (`planaco.charts`), so **matplotlib is no longer needed**. This removes the matplotlib theme from `style.py` and drops the dependency — making the package fully SVG-native.

## Changes

- **`style.py`** — keep the design tokens (`PALETTE`, `theme_colors`, `PERCENTILE_COLORS`, `percentile_color`, `CRITICALITY_STOPS`); remove the matplotlib theme (`apply_planaco_style`, `mode_bar_colors`, `CRITICALITY_CMAP`) and the matplotlib import. Module drops from ~120 to 11 statements.
- **`pyproject.toml`** — remove `matplotlib` from dependencies and from the mypy overrides.
- Prune the matplotlib-specific tests; update `brand/STYLE_GUIDE.md` and the website copy to reflect SVG-native rendering.

## Runtime dependencies

Before: `click, matplotlib, seaborn, numpy, PyYAML, networkx` → After: **`click, numpy, PyYAML, cairosvg`** (across this and the two prior PRs).

## Verification

With **matplotlib uninstalled from the environment**, `import planaco`, `project.plot()`, `project.plot_dependency_graph()`, and the style tokens all work. Full gate suite green: ruff ✓ · black ✓ · mypy ✓ · **pytest 301 passed, 100% coverage**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)