### PR TITLE
Release v0.3.0: SVG-native rendering, lighter dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Estimating the time it takes to complete a task or project is hard. Traditional 
 
 **Planaco helps you make better estimates by modeling tasks as random processes**, accounting for uncertainty and task dependencies through Monte Carlo simulation.
 
-> **Status:** Planaco is in **alpha** (v0.2.3). The public API may still change between releases.
+> **Status:** Planaco is in **alpha** (v0.3.0). The public API may still change between releases.
 
 ## Features
 

--- a/brand/STYLE_GUIDE.md
+++ b/brand/STYLE_GUIDE.md
@@ -80,9 +80,9 @@ These carry meaning in data viz — use them only for what they mean.
 **Percentiles warm as risk climbs:** gold → amber → coral. This is intentional and
 consistent everywhere — a reader learns it once.
 
-**Don't** reintroduce the generic seaborn purple, or the old green/red min–max
-coloring. Green/red clashes with navy+gold and carries the wrong (pass/fail)
-connotation for a probabilistic tool.
+**Don't** reintroduce generic charting-library defaults (grey background, purple
+bars), or the old green/red min–max coloring. Green/red clashes with navy+gold
+and carries the wrong (pass/fail) connotation for a probabilistic tool.
 
 ---
 

--- a/src/planaco/__init__.py
+++ b/src/planaco/__init__.py
@@ -135,7 +135,7 @@ from planaco.distributions import (
 from planaco.task import Task
 from planaco.project import Project
 
-__version__ = "0.2.3"
+__version__ = "0.3.0"
 
 __all__ = [
     # Core classes


### PR DESCRIPTION
## Summary

Marks the release of the SVG-native rendering work and the dependency cleanup.

- **Version** `0.2.3 → 0.3.0` (`src/planaco/__init__.py`, README status line). Minor bump per alpha semver — this cycle has breaking changes: `plot()` / `plot_dependency_graph()` now return a `Chart` (not a matplotlib `Figure`), and `plot_dependency_graph()` dropped its matplotlib-only `figsize`/`node_size`/`font_size` params.
- **Docs scrub** — removed the last stale dependency name from `STYLE_GUIDE.md`. `git grep` now finds **zero** matplotlib/seaborn/networkx references in any tracked file.

## Highlights since 0.2.3
- Native SVG chart renderer (`planaco.charts`) — on-brand histogram, CDF, dependency graph; saves `.svg` or `.png`.
- Brand style system (`brand/STYLE_GUIDE.md`, `src/planaco/style.py` tokens, `website/index.html`).
- Runtime deps trimmed to **`click, numpy, PyYAML, cairosvg`**.

## Verification

ruff ✓ · black ✓ · mypy ✓ · pytest **301 passed, 100% coverage**. `planaco --version` reports `0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)