### PR TITLE
Align README and add CHANGELOG for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to **planaco** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/). While in
+alpha (`0.x`), the public API may change between minor releases.
+
+## [0.3.0] - 2026-06-20
+
+The "SVG-native" release: charts are now rendered as crisp, on-brand SVG, and the
+heavy plotting dependencies are gone.
+
+### Changed
+- **Charts now render as native SVG** via the new `planaco.charts` module instead
+  of matplotlib/seaborn. `Project.plot()` and `Project.plot_dependency_graph()`
+  return a `Chart` (save with `chart.save(path)` to `.svg` or `.png`; renders
+  inline in notebooks) rather than a matplotlib `Figure`. **Breaking.**
+- `Project.plot_dependency_graph()` dropped the matplotlib-only `figsize`,
+  `node_size`, and `font_size` parameters. **Breaking.**
+
+### Added
+- Brand & style system: `brand/STYLE_GUIDE.md`, shared design tokens in
+  `planaco.style` (`PALETTE`, `theme_colors`, `PERCENTILE_COLORS`,
+  `percentile_color`, `CRITICALITY_STOPS`), and a landing-page mockup in
+  `website/index.html`.
+- On-brand visuals: navy distribution bars with a gold modal bar, percentile
+  markers warming gold → amber → coral, a gold-filled cumulative curve, and a
+  self-laid-out dependency graph (teal start / navy middle / gold end).
+- Optional `title` argument on `planaco.charts.histogram()`.
+- `scripts/generate_example_plots.py` to regenerate the example images.
+
+### Removed
+- Dropped the `matplotlib`, `seaborn`, and `networkx` runtime dependencies. The
+  dependency / critical-path engine was always pure Python; rendering is now SVG.
+  Runtime dependencies are now just `click`, `numpy`, `PyYAML`, and `cairosvg`.
+
+## [0.2.3] and earlier
+
+Tagged releases (`v0.2.0`–`v0.2.3`) predate this changelog. See the
+[git history](https://github.com/sepam/planaco/commits/master) and
+[tags](https://github.com/sepam/planaco/tags) for details.
+
+[0.3.0]: https://github.com/sepam/planaco/tree/v0.3.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/sepam/planaco/v0.2.3/brand/planaco-lockup-dark.svg">
-    <img src="https://raw.githubusercontent.com/sepam/planaco/v0.2.3/brand/planaco-lockup-light.svg" alt="planaco" width="320">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/sepam/planaco/v0.3.0/brand/planaco-lockup-dark.svg">
+    <img src="https://raw.githubusercontent.com/sepam/planaco/v0.3.0/brand/planaco-lockup-light.svg" alt="planaco" width="320">
   </picture>
 
   **Probabilistic Project Planning with Monte Carlo Simulation**
@@ -84,7 +84,7 @@ task = Task(
 ```
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/sepam/planaco/v0.2.3/example/task_definition.png" alt="Task Definition" width="600"/>
+  <img src="https://raw.githubusercontent.com/sepam/planaco/v0.3.0/example/task_definition.png" alt="Task Definition" width="600"/>
 </div>
 
 ### Build Projects with Dependencies
@@ -113,7 +113,7 @@ project.add_task(deploy, depends_on=[testing])
 ```
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/sepam/planaco/v0.2.3/example/project_estimation.png" alt="Project Estimation" width="700"/>
+  <img src="https://raw.githubusercontent.com/sepam/planaco/v0.3.0/example/project_estimation.png" alt="Project Estimation" width="700"/>
 </div>
 
 ---
@@ -157,7 +157,7 @@ project.plot(n=10000, hist=True)
 ```
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/sepam/planaco/master/example/monte_carlo_estimation.png" alt="Monte Carlo Histogram" width="600"/>
+  <img src="https://raw.githubusercontent.com/sepam/planaco/v0.3.0/example/monte_carlo_estimation.png" alt="Monte Carlo Histogram" width="600"/>
 </div>
 
 ### Cumulative Distribution
@@ -170,7 +170,7 @@ project.plot(n=10000, hist=False)
 ```
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/sepam/planaco/master/example/monte_carlo_cumulative.png" alt="Cumulative Distribution" width="600"/>
+  <img src="https://raw.githubusercontent.com/sepam/planaco/v0.3.0/example/monte_carlo_cumulative.png" alt="Cumulative Distribution" width="600"/>
 </div>
 
 The cumulative distribution shows the probability of completing the project within a given timeframe, accounting for both parallel and sequential task execution.
@@ -324,7 +324,7 @@ planaco graph project.yaml                # Visualize the task dependency graph
 ```
 
 <div align="center">
-  <img src="https://raw.githubusercontent.com/sepam/planaco/master/example/project_dependency_graph.png" alt="Task Dependency Graph" width="800"/>
+  <img src="https://raw.githubusercontent.com/sepam/planaco/v0.3.0/example/project_dependency_graph.png" alt="Task Dependency Graph" width="800"/>
 </div>
 
 Charts render as crisp, on-brand SVG (or PNG) — see the [brand &amp; style guide](brand/STYLE_GUIDE.md).


### PR DESCRIPTION
## Summary

Final alignment for the **v0.3.0** release.

- **README asset URLs** all pinned to the `v0.3.0` tag (they were split between `v0.2.3` and `master`). A released README — which is also the PyPI long description — should pin to a stable tag, not a moving branch.
- **`CHANGELOG.md`** added (Keep a Changelog format) documenting the 0.3.0 SVG-native release: the `Chart` return type, dropped matplotlib-only params, the brand/style system, and the removal of `matplotlib`/`seaborn`/`networkx`.

After this merges, I'll tag `v0.3.0` at the merge commit so the pinned URLs resolve. Tagging does **not** publish to PyPI — that only happens when a GitHub *Release* is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)