### PR TITLE
Repo/PyPI presentation polish + 0.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/). While in
 alpha (`0.x`), the public API may change between minor releases.
 
+## [0.3.1] - 2026-07-05
+
+Packaging and presentation polish. No library code or public API changes.
+
+### Added
+- `Documentation`, `Issues`, and `Changelog` links in `[project.urls]`, using
+  PyPI's recognized labels so they render with their icons on the project page.
+
+### Changed
+- The `Homepage` project URL now points at the project website
+  (https://sepam.github.io/planaco/) instead of the GitHub repository.
+- Trimmed the README badge row from eight badges to the four canonical trust
+  badges (CI, PyPI version, Python versions, License).
+
 ## [0.3.0] - 2026-06-20
 
 The "SVG-native" release: charts are now rendered as crisp, on-brand SVG, and the
@@ -41,4 +55,5 @@ Tagged releases (`v0.2.0`–`v0.2.3`) predate this changelog. See the
 [git history](https://github.com/sepam/planaco/commits/master) and
 [tags](https://github.com/sepam/planaco/tags) for details.
 
+[0.3.1]: https://github.com/sepam/planaco/tree/v0.3.1
 [0.3.0]: https://github.com/sepam/planaco/tree/v0.3.0

--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@
   [![PyPI version](https://img.shields.io/pypi/v/planaco.svg?style=flat-square)](https://pypi.org/project/planaco/)
   [![Python versions](https://img.shields.io/pypi/pyversions/planaco.svg?style=flat-square)](https://pypi.org/project/planaco/)
   [![License](https://img.shields.io/github/license/sepam/planaco?style=flat-square)](LICENSE.md)
-  ![Status](https://img.shields.io/badge/status-alpha-orange?style=flat-square)
-  [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?style=flat-square)](https://github.com/psf/black)
-  [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json&style=flat-square)](https://github.com/astral-sh/ruff)
-  [![Checked with mypy](https://img.shields.io/badge/mypy-checked-blue?style=flat-square)](https://mypy-lang.org/)
 
   <p align="center">
     <a href="https://sepam.github.io/planaco/"><b>Website</b></a> •

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,10 @@ planaco = "planaco.cli:main"
 
 [project.urls]
 Homepage = "https://sepam.github.io/planaco/"
+Documentation = "https://github.com/sepam/planaco#readme"
 Repository = "https://github.com/sepam/planaco"
+Issues = "https://github.com/sepam/planaco/issues"
+Changelog = "https://github.com/sepam/planaco/blob/master/CHANGELOG.md"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/planaco/__init__.py
+++ b/src/planaco/__init__.py
@@ -135,7 +135,7 @@ from planaco.distributions import (
 from planaco.task import Task
 from planaco.project import Project
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = [
     # Core classes


### PR DESCRIPTION
Packaging- and presentation-only changes that improve how planaco shows up on PyPI and GitHub, plus the 0.3.1 version bump to ship them. **No library code or public API changes.**

## Changes

**`pyproject.toml` — `[project.urls]`**
- Added `Documentation`, `Issues`, and `Changelog` using PyPI's canonical labels, so they render with their recognized icons on the project page (`Homepage` already points at the website).

**`README.md` — badges**
- Trimmed the badge row from 8 to the 4 canonical trust badges (CI, PyPI version, Python versions, License). The alpha status is already stated in prose; the black/ruff/mypy tooling badges read as noise.

**Release**
- `__version__` → `0.3.1` and a matching CHANGELOG entry.

## Why 0.3.1

The 0.3.0 release on PyPI is immutable, so the expanded URLs and the website `Homepage` won't appear on the package page until a new release. Cutting 0.3.1 surfaces them and — because publishing goes through Trusted Publishing — stamps the github.com / github.io links as verified.

## To publish after merge

Create a GitHub Release tagged `v0.3.1`; `publish.yml` builds and publishes to PyPI via OIDC automatically.

## Context

Follow-up to the website launch (#24). Full rationale in the local landing-page/repo-presentation checklist (salvaged from an earlier research run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
